### PR TITLE
ソートに関する変更

### DIFF
--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -118,7 +118,7 @@ class PricesController < ApplicationController
 
   # :search_prices_formはasで指定しない限り自動的にオブジェクトのクラス名となる
   def search_params
-    params.fetch(:search_prices_form, {}).permit(:city_id, :item_name, :min_price, :max_price, :trend, :sort_order)
+    params.fetch(:search_prices_form, {}).permit(:city_id, :item_name, :min_price, :max_price, :trend, :sort_key)
   end
 
   # def price_params

--- a/app/views/prices/_search.html.erb
+++ b/app/views/prices/_search.html.erb
@@ -17,14 +17,9 @@
           %
         </div>
 
-        <div data-controller="toggle" class="flex">
-          <span>最新更新順：</span>
-          <label for="toggle-checkbox" class="relative inline-flex items-center cursor-pointer">
-            <%= form.check_box :sort_order, { id: "toggle-checkbox", class: "sr-only peer", data: { toggle_target: "checkbox" } }, true, false %>
-
-            <div class="w-8 h-5 bg-gray-300 peer-checked:bg-green-500 rounded-full transition duration-300 z-0"></div>
-            <div class="absolute left-1 top-1.2 w-3.5 h-3.5 bg-white rounded-full transition-transform duration-300 peer-checked:translate-x-2.5 z-0"></div>
-          </label>
+        <div class="flex">
+          <%= form.label :sort_key, t("helpers.label.sort") %>
+          <%= form.select :sort_key, options_for_select([["最新更新順", "newest"], ["価格割合順", "price_percentage"], ["五十音順", "item_name"]], @search_form.sort_key), class: "border rounded-sm p-0.5 w-48" %>
         </div>
       </div>
 

--- a/app/views/prices/_table.html.erb
+++ b/app/views/prices/_table.html.erb
@@ -17,7 +17,7 @@
     </tbody>
   </table>
 
-  <% if @search_form.errors.any? %>
+  <% if @search_form.errors.present? %>
   <div class="text-center py-2">
     <%= render "shared/error_messages", object: @search_form %>
   </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
-<% if object.errors.any? %>
+<% if object.errors.present? %>
 <div class="mt-1 text-xs md:text-sm text-red-500">
   <ul>
     <% object.errors.full_messages.each do |message| %>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -5,4 +5,5 @@ ja:
         search_prices_form:
           attributes:
             base:
-              city_or_item_required: "都市または商品のいずれかを指定してください"
+              city_or_item_required: 都市または商品のいずれかを指定してください
+              invalid_sort_key: ソートの指定に問題があるようです

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,7 @@ ja:
       city: 都市：
       item: 商品：
       trend: 動向：
+      sort: ソート：
   header:
     links:
       root: Resonance-MKT

--- a/db/migrate/20250205133316_add_index_to_items_name.rb
+++ b/db/migrate/20250205133316_add_index_to_items_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToItemsName < ActiveRecord::Migration[7.2]
+  def change
+    add_index :items, :name
+  end
+end

--- a/db/migrate/20250206060331_add_index_to_prices.rb
+++ b/db/migrate/20250206060331_add_index_to_prices.rb
@@ -1,0 +1,5 @@
+class AddIndexToPrices < ActiveRecord::Migration[7.2]
+  def change
+    add_index :prices, [ :updated_at, :price_percentage ], order: { updated_at: :desc, price_percentage: :desc }, name: "index_prices_on_updated_at_and_price_percentage"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_17_050937) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_06_060331) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_050937) do
 
   create_table "items", force: :cascade do |t|
     t.string "name"
+    t.index ["name"], name: "index_items_on_name"
   end
 
   create_table "prices", force: :cascade do |t|
@@ -31,6 +32,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_17_050937) do
     t.datetime "updated_at", null: false
     t.index ["city_id"], name: "index_prices_on_city_id"
     t.index ["item_id"], name: "index_prices_on_item_id"
+    t.index ["updated_at", "price_percentage"], name: "index_prices_on_updated_at_and_price_percentage", order: :desc
   end
 
   add_foreign_key "prices", "cities"


### PR DESCRIPTION
元々ソート機能はつけていたものの、その処理をできる限り早めるための変更。
具体的には prices の updated_at, price_percentage と、items の name にインデックスを追加。

ソートは 最新更新順、価格割合順、五十音順 の3種類。

※3種類になったことに伴い、tailwindのpeerを使ったトグルデザインは変更。