### PR TITLE
price更新時のエラーハンドリング改善

### DIFF
--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -96,7 +96,7 @@ class PricesController < ApplicationController
 
   # 更新の競合に関してはアプリの用途的に気にしない
   def update_by_city
-    if request.get?
+    if request.get? || request.head?
       redirect_to edit_by_city_prices_path
       return
     end

--- a/app/views/prices/_consent_form.html.erb
+++ b/app/views/prices/_consent_form.html.erb
@@ -3,6 +3,7 @@
     <p>よろしいですか？</p>
   </div>
   <%= form_with url: update_by_city_prices_path, method: :patch, local: true, data: { turbo: false } do |form| %>
+  <%= form.hidden_field :city_id, value: @city_id %>
   <div class="my-4">
     <% @prices.each do |id, attributes| %>
 

--- a/app/views/prices/_search.html.erb
+++ b/app/views/prices/_search.html.erb
@@ -30,7 +30,7 @@
         </div>
 
         <div class="flex space-x-2">
-          <%= form.label :trend, t("helpers.label.trend") %>
+          <span>動向：</span>
 
           <label for="trend_all" class="flex space-x-0.5 cursor-pointer items-center">
             <%= form.radio_button :trend, "all", id: "trend_all" %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,12 @@
 <% flash.each do |message_type, message| %>
-<div class="alert-<%= message_type %> animate-flash z-20 h-8 flex items-center pl-4 text-white bg-gray-400">
-  <%= message %>
+<!-- シンボルの可能性もあるため to_s で文字列化 -->
+<% bg_color =
+    case message_type.to_s
+    when "success" then "bg-green-600"
+    when "danger" then "bg-red-500"
+    else "bg-gray-400"
+  end %>
+<div class="flex items-center pl-4 py-1 text-white z-20 animate-flash <%= bg_color %>">
+  <%= simple_format(message) %>
 </div>
 <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activerecord:
+    attributes:
+      price:
+        price_percentage: 価格割合
+        trend: 動向

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       post :add_price_field
       get :confirm
       post :confirm
+      get :update_by_city
       patch :update_by_city
     end
   end


### PR DESCRIPTION
内容：
モデルにバリデーションはあったが、エラー時のハンドリングが疎かだったため修正。

具体的にはバリデーションエラー時に、フラッシュメッセージを表示させ edit_by_city のビューをレンダリング。
※トランザクションで全ての更新処理を確認した上でロールバック。

その他：
・「Incorrect use of ＜label for=FORM_ELEMENT＞」エラーのための修正
（自分の場合動作に影響は及ばなかったものの、ブラウザのコンソールに出たため対象のフォームラベル部分を修正）

個人メモ：
redirect_to  edit_by_city をしたかったものの、422エラーが出てしまうためrenderに変更。
renderなのでurlはprices/update_by_cityのままであり、リロードした場合のためにgetのルーティングとgetの場合の処理を追加。
@cityに渡すためのcity_idはpriceからとっても良かったものの、とりあえずバケツリレーで渡す形に。
