### PR TITLE
デプロイを通す為の修正

### DIFF
--- a/db/migrate/20250117050919_create_items.rb
+++ b/db/migrate/20250117050919_create_items.rb
@@ -1,7 +1,0 @@
-class CreateItems < ActiveRecord::Migration[7.2]
-  def change
-    create_table :items do |t|
-      t.string :name
-    end
-  end
-end

--- a/db/migrate/20250205133316_add_index_to_items_name.rb
+++ b/db/migrate/20250205133316_add_index_to_items_name.rb
@@ -1,5 +1,0 @@
-class AddIndexToItemsName < ActiveRecord::Migration[7.2]
-  def change
-    add_index :items, :name
-  end
-end

--- a/db/migrate/20250206060331_add_index_to_prices.rb
+++ b/db/migrate/20250206060331_add_index_to_prices.rb
@@ -1,5 +1,0 @@
-class AddIndexToPrices < ActiveRecord::Migration[7.2]
-  def change
-    add_index :prices, [ :updated_at, :price_percentage ], order: { updated_at: :desc, price_percentage: :desc }, name: "index_prices_on_updated_at_and_price_percentage"
-  end
-end

--- a/db/migrate/20250208150050_create_cities.rb
+++ b/db/migrate/20250208150050_create_cities.rb
@@ -1,7 +1,7 @@
 class CreateCities < ActiveRecord::Migration[7.2]
   def change
     create_table :cities do |t|
-      t.string :name
+      t.string :name, null: false
     end
   end
 end

--- a/db/migrate/20250208150117_create_items.rb
+++ b/db/migrate/20250208150117_create_items.rb
@@ -1,0 +1,10 @@
+class CreateItems < ActiveRecord::Migration[7.2]
+  def change
+    create_table :items do |t|
+      t.string :name, null: false
+    end
+
+    # nameカラムにインデックスを追加
+    add_index :items, :name
+  end
+end

--- a/db/migrate/20250208150131_create_prices.rb
+++ b/db/migrate/20250208150131_create_prices.rb
@@ -10,6 +10,6 @@ class CreatePrices < ActiveRecord::Migration[7.2]
     end
 
     # "updated_at"と"price_percentage"にインデックスを追加
-    add_index :prices, [:updated_at, :price_percentage], order: { updated_at: :desc, price_percentage: :desc }, name: "index_prices_on_updated_at_and_price_percentage"
+    add_index :prices, [ :updated_at, :price_percentage ], order: { updated_at: :desc, price_percentage: :desc }, name: "index_prices_on_updated_at_and_price_percentage"
   end
 end

--- a/db/migrate/20250208150131_create_prices.rb
+++ b/db/migrate/20250208150131_create_prices.rb
@@ -8,5 +8,8 @@ class CreatePrices < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
+
+    # "updated_at"と"price_percentage"にインデックスを追加
+    add_index :prices, [:updated_at, :price_percentage], order: { updated_at: :desc, price_percentage: :desc }, name: "index_prices_on_updated_at_and_price_percentage"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_060331) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_08_150131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cities", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
   end
 
   create_table "items", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.index ["name"], name: "index_items_on_name"
   end
 


### PR DESCRIPTION
なぜかitem_idが見つからず、シードデータ作成中に失敗してしまうので修正。

一旦マイグレーションファイルを作り直してみた段階。

ローカルでは以前からシードデータも作成でき、アプリとして問題なく動作しているのでデプロイで試すしかない状況。

※デプロイ時のログ
Caused by:
NoMethodError: undefined method `item_id=' for an instance of Price (NoMethodError)
Did you mean?  items_id=
/opt/render/project/src/db/seeds.rb:47:in `block (2 levels) in <main>'
/opt/render/project/src/db/seeds.rb:41:in `block in <main>'
/opt/render/project/src/db/seeds.rb:40:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
Citiesデータ作成成功
Itemsデータ作成完了
==> Build failed 😞
==> Common ways to troubleshoot your deploy: https://render.com/docs/troubleshooting-deploys

本来「価格データが作成されました。」というログが表示されるはず。