### PR TITLE
セッションによるフォーム認証追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,3 @@
 
 /node_modules
 /vendor/bundle
-
-# csvファイル
-/cities.csv
-/items.csv

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
 
   gem "rspec-rails"
   gem "factory_bot_rails"
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,10 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.1)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     factory_bot (6.5.0)
@@ -359,6 +363,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   factory_bot_rails
   jbuilder
   jsbundling-rails

--- a/app/controllers/csv_import_controller.rb
+++ b/app/controllers/csv_import_controller.rb
@@ -1,4 +1,5 @@
 class CsvImportController < ApplicationController
+  before_action :authenticate, only: [ :index ]
   require "csv"
 
   def import
@@ -41,5 +42,13 @@ class CsvImportController < ApplicationController
   def set_flash_and_render(type, message)
     flash.now[type] = message
     render :index, status: :unprocessable_entity
+  end
+
+  # フォーム認証
+  def authenticate
+    unless session[:authenticated]
+      session[:return_to] = request.fullpath
+      redirect_to login_path, alert: "ログインが必要です"
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,15 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  # セッションなのでsession_store.rbにより5分で自動ログアウト
+  def create
+    if params[:password] == ENV["AUTH_PASSWORD"]
+      session[:authenticated] = true
+      redirect_to session[:return_to] || cities_path, success: "ログインしました"
+    else
+      flash.now.alert = "パスワードが違います"
+      render :new, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,18 @@
+<div class="container mx-auto py-8">
+  <h1 class="text-center mx-8 md:mx-24 mb-6 pb-2 text-2xl sm:text-3xl border-b-2 border-violet-800">管理者ページ</h1>
+
+  <div class="flex flex-col items-center text-gray-700">
+    <h2 class="mb-8 text-lg sm:text-xl">ログインが必要です</h2>
+    <%= form_with url: login_path do |form| %>
+    <div class="w-80 p-4 border rounded border-black/50 shadow-lg">
+      <div class="flex flex-col items-center">
+        <%= form.label :password, t("helpers.label.password"), class: "text-lg" %>
+        <%= form.password_field :password, class: "text-center w-5/6 border-b border-black/50 bg-transparent outline-none rounded-none" %>
+      </div>
+      <div class="text-center pt-4">
+        <%= form.submit t("helpers.submit.login"), class: "px-2 py-1 bg-violet-800 rounded text-sm text-white cursor-pointer hover:bg-gray-500 transition duration-300" %>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static_pages/tutorial.html.erb
+++ b/app/views/static_pages/tutorial.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:title, t(".title")) %>
 
-<div class="container mx-auto px-4 py-8">
+<div class="container mx-auto py-8">
   <!-- タイトル -->
-  <h1 class="text-center mx-8 md:mx-20 mb-12 pb-2 text-2xl sm:text-3xl border-b-2 border-violet-800">
+  <h1 class="text-center mx-8 md:mx-24 mb-12 pb-2 text-2xl sm:text-3xl border-b-2 border-violet-800">
     アプリについて
   </h1>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,11 +5,13 @@ ja:
       confirm: 確定して更新
       update: 更新
       import: 取り込み
+      login: ログイン
     label:
       city: 都市：
       item: 商品：
       trend: 動向：
       sort: ソート：
+      password: パスワード
   cities:
     index:
       title: 都市取り込み

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,12 @@ Rails.application.routes.draw do
     end
   end
 
-  get "tutorial", to: "static_pages#tutorial"
+  # 認証用のルート
+  get "login", to: "sessions#new"
+  post "login", to: "sessions#create"
+  delete "logout", to: "sessions#destroy"
 
+  get "tutorial", to: "static_pages#tutorial"
   get "privacy_policy", to: "static_pages#privacy_policy"
   get "terms_of_service", to: "static_pages#terms_of_service"
   get "contact", to: "static_pages#contact"


### PR DESCRIPTION
セッションを使ったフォーム認証を追加

これにより「city」や「item」のデータを追加する画面へのアクセスをパスワードで制限。