### PR TITLE
Pricesデータの追加作成機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,14 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # フォーム認証
+  def authenticate
+    unless session[:authenticated]
+      session[:return_to] = request.fullpath
+      redirect_to login_path, alert: "ログインが必要です"
+    end
+  end
+
   def should_cleanup?
     # 最後のクリーンアップから6時間以上経過している場合のみ実行
     last_cleanup = Rails.cache.read("last_cleanup_time")

--- a/app/controllers/csv_import_controller.rb
+++ b/app/controllers/csv_import_controller.rb
@@ -43,12 +43,4 @@ class CsvImportController < ApplicationController
     flash.now[type] = message
     render :index, status: :unprocessable_entity
   end
-
-  # フォーム認証
-  def authenticate
-    unless session[:authenticated]
-      session[:return_to] = request.fullpath
-      redirect_to login_path, alert: "ログインが必要です"
-    end
-  end
 end

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -5,7 +5,7 @@
     robots: "noindex, nofollow"
 ) %>
 
-<h1 class="flex justify-center mx-20 mb-4 text-3xl border-b">Cities</h1>
+<h1 class="text-center mx-8 md:mx-44 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Cities</h1>
 
 <%= form_with url: import_cities_path, local: false, multipart: true, data: { controller: "file-input" } do |form| %>
 <div class="flex items-center justify-center mb-2">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,7 +5,8 @@
     robots: "noindex, nofollow"
 ) %>
 
-<h1 class="flex justify-center mx-20 mb-4 text-3xl border-b">Items</h1>
+<h1 class="text-center mx-8 md:mx-44 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Items</h1>
+
 <%= form_with url: import_items_path, local: true, multipart: true, data: { controller: "file-input" } do |form| %>
 <div class="flex items-center justify-center mb-2">
   <label>

--- a/app/views/prices/_search.html.erb
+++ b/app/views/prices/_search.html.erb
@@ -6,7 +6,7 @@
       <div class="mr-2 sm:mr-4 md:mr-10 lg:mr-20">
         <div class="sm:flex">
           <%= form.label :city_id, t("helpers.label.city") %>
-          <%= form.collection_select :city_id, @cities, :id, :name, { include_blank: "未選択" }, { class: "w-40 sm:w-44 p-0.5 border rounded-sm text-xs sm:text-sm" } %>
+          <%= form.collection_select :city_id, @cities, :id, :name, { include_blank: "未選択" }, { class: "w-40 sm:w-44 p-0.5 border rounded-sm text-xs sm:text-sm cursor-pointer" } %>
         </div>
 
         <div class="sm:flex mt-1.5 mb-1">
@@ -21,7 +21,7 @@
 
         <div class="flex mt-1.5">
           <%= form.label :sort_key, t("helpers.label.sort") %>
-          <%= form.select :sort_key, options_for_select([["最新更新順", "newest"], ["価格割合順", "price_percentage"], ["五十音順", "item_name"]], @search_form.sort_key), {}, { class: "pr-1 border-b text-xs sm:text-sm" } %>
+          <%= form.select :sort_key, options_for_select([["最新更新順", "newest"], ["価格割合順", "price_percentage"], ["五十音順", "item_name"]], @search_form.sort_key), {}, { class: "pr-1 border-b text-xs sm:text-sm cursor-pointer" } %>
         </div>
       </div>
 

--- a/app/views/prices/new.html.erb
+++ b/app/views/prices/new.html.erb
@@ -1,0 +1,14 @@
+<% set_meta_tags(
+    title: t(".title"),
+    description: "このページはパスワードで保護されており、認証が必要です。",
+    # 検索エンジンにインデックスされないように設定
+    robots: "noindex, nofollow"
+) %>
+
+<h1 class="text-center mx-8 md:mx-44 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Prices</h2>
+
+  <%= form_with url: prices_path, method: :post do %>
+  <div class="flex justify-center mb-6">
+    <%= submit_tag t("helpers.submit.create"), class: "w-1/5 md:w-1/6 rounded-full border border-slate-600 bg-slate-700 text-white font-normal cursor-pointer hover:text-black hover:bg-white hover:shadow-md transition duration-200" %>
+  </div>
+  <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,11 +1,12 @@
 ja:
   helpers:
     submit:
-      next: 次に進む
-      confirm: 確定して更新
-      update: 更新
-      import: 取り込み
       login: ログイン
+      import: 取り込み
+      create: 新規追加
+      next: 次に進む
+      update: 更新
+      confirm: 確定して更新
     label:
       city: 都市：
       item: 商品：
@@ -25,6 +26,8 @@ ja:
       title: トップページ
     edit_by_city:
       title: 更新ページ
+    new:
+      title: 管理者ページ(価格情報追加)
   static_pages:
     privacy_policy:
       title: プライバシーポリシー

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     collection { post :import }
   end
 
-  resources :prices do
+  resources :prices, only: [ :index, :new, :create ] do
     resources :interests, only: [ :create ]
     collection do
       get :search
@@ -27,7 +27,6 @@ Rails.application.routes.draw do
   # 認証用のルート
   get "login", to: "sessions#new"
   post "login", to: "sessions#create"
-  delete "logout", to: "sessions#destroy"
 
   get "tutorial", to: "static_pages#tutorial"
   get "privacy_policy", to: "static_pages#privacy_policy"


### PR DESCRIPTION
Pricesデータの追加作成機能を追加。

具体的にはcreateアクションを追加し、bulk insertでできるだけ高速に処理。

その他：
safariで「本当にこのフォームを再送信しますか？」が表示された時に、「OK」を選択すると404エラーページが表示されてしまうようだったので、原因と見られるルーティングに status: :see_other を追加。