### PR TITLE
itemsとcitiesのデータを削除する機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   # chromeの検証ツールでデバイスモード使用中に画面遷移をすると406エラーページが表示されるのは以下の"allow_browser versions: :modern"が原因
-  allow_browser versions: :modern
   add_flash_types :success, :danger
   before_action :cleanup_old_interests, if: :should_cleanup?
 

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -2,4 +2,10 @@ class CitiesController < CsvImportController
   def index
     @cities = City.all
   end
+
+  def destroy
+    @city = City.find(params[:id])
+    @city.destroy
+    flash.now[:success] = "削除しました。"
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,10 @@ class ItemsController < CsvImportController
   def index
     @items = Item.all
   end
+
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    flash.now[:success] = "削除しました。"
+  end
 end

--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -68,7 +68,7 @@ class PricesController < ApplicationController
       @city = City.find(session[:city_id])
       session[:added_item_ids] = []
     else
-      redirect_to root_path, status: :see_other, alert: "更新操作途中で一定時間経過したためセッションが切れました"
+      redirect_to root_path, status: :found, alert: "更新操作途中で一定時間経過したためセッションが切れました"
     end
   end
 
@@ -77,7 +77,7 @@ class PricesController < ApplicationController
     # セッションが切れていないか確認
     if session[:added_item_ids].nil?
       flash.alert = "更新途中で一定時間(5分)経過したためセッションが切れました"
-      redirect_to edit_by_city_prices_path, status: :see_other
+      redirect_to edit_by_city_prices_path, status: :found
       return
     end
 

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,5 +1,5 @@
 class City < ApplicationRecord
-  has_many :prices
+  has_many :prices, dependent: :destroy
   has_many :items, through: :prices
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  has_many :prices
+  has_many :prices, dependent: :destroy
   has_many :cities, through: :prices
 
   validates :name, presence: true, uniqueness: true

--- a/app/views/cities/_city.html.erb
+++ b/app/views/cities/_city.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag city do %>
+<% if city.present? %>
+<div class="flex justify-center">
+  <div class="w-4/5 sm:w-2/3 border-b">
+    <div class="flex justify-between items-center pl-6 sm:pl-8 pr-6 sm:pr-10 py-1">
+      <span class="text-xs sm:text-sm"><%= city.name %></span>
+      <%= link_to t("cities.links.destroy"), city,
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+          class: "py-0.5 px-1.5 text-blue-400 text-xs sm:text-sm font-thin bg-transparent border border-blue-400 rounded cursor-pointer hover:bg-gray-200 hover:text-gray-400 hover:border-transparent"
+        %>
+    </div>
+  </div>
+</div>
+<% else %>
+<p class="text-gray-500 text-center">データがありません</p>
+<% end %>
+<% end %>

--- a/app/views/cities/destroy.turbo_stream.erb
+++ b/app/views/cities/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "flash", partial: "shared/flash_message" %>
+
+<%= turbo_stream.remove @city %>

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -5,7 +5,7 @@
     robots: "noindex, nofollow"
 ) %>
 
-<h1 class="text-center mx-8 md:mx-44 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Cities</h1>
+<h1 class="text-center mx-8 md:mx-32 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Cities</h1>
 
 <%= form_with url: import_cities_path, local: false, multipart: true, data: { controller: "file-input" } do |form| %>
 <div class="flex items-center justify-center mb-2">
@@ -22,15 +22,6 @@
 </div>
 <% end %>
 
-<div class="flex justify-center w-full mb-4">
-  <div class="border">
-    <% if @cities.present? %>
-    <% @cities.each do |city| %>
-    <p class="flex border-b p-1 justify-center"><%= city.name %></p>
-    </tr>
-    <% end %>
-    <% else %>
-    <p colspan="1">データがありません</p>
-    <% end %>
-  </div>
+<div id="cities" class="mb-8">
+  <%= render @cities %>
 </div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag item do %>
+<% if item.present? %>
+<div class="flex justify-center">
+  <div class="w-4/5 md:w-2/3 border-b">
+    <div class="flex justify-between items-center pl-6 sm:pl-8 pr-6 sm:pr-10 py-1">
+      <span class="text-xs sm:text-sm"><%= item.name %></span>
+      <%= link_to t("items.links.destroy"), item,
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+          class: "py-0.5 px-1.5 text-blue-400 text-xs sm:text-sm font-thin bg-transparent border border-blue-400 rounded cursor-pointer hover:bg-gray-200 hover:text-gray-400 hover:border-transparent"
+        %>
+    </div>
+  </div>
+</div>
+<% else %>
+<p class="text-gray-500 text-center">データがありません</p>
+<% end %>
+<% end %>

--- a/app/views/items/destroy.turbo_stream.erb
+++ b/app/views/items/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "flash", partial: "shared/flash_message" %>
+
+<%= turbo_stream.remove @item %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -5,7 +5,7 @@
     robots: "noindex, nofollow"
 ) %>
 
-<h1 class="text-center mx-8 md:mx-44 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Items</h1>
+<h1 class="text-center mx-8 md:mx-32 mb-8 py-4 text-2xl sm:text-3xl border-b-2 border-violet-800">Items</h1>
 
 <%= form_with url: import_items_path, local: true, multipart: true, data: { controller: "file-input" } do |form| %>
 <div class="flex items-center justify-center mb-2">
@@ -22,14 +22,6 @@
 </div>
 <% end %>
 
-<div class="flex justify-center w-full mb-4">
-  <div class="border">
-    <% if @items.present? %>
-    <% @items.each do |item| %>
-    <p class="flex border-b p-1 justify-center"><%= item.name %></p>
-    <% end %>
-    <% else %>
-    <p colspan="1">データがありません</p>
-    <% end %>
-  </div>
+<div id="items" class="mb-8">
+  <%= render @items %>
 </div>

--- a/app/views/prices/_city_selector.html.erb
+++ b/app/views/prices/_city_selector.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-center">どの都市の商品を更新しますか？</h1>
+<p>どの都市の商品を更新しますか？</p>
 
 <%= form_with url: edit_by_city_prices_path, method: :post, local: true, data: { turbo: false } do |form| %>
 

--- a/app/views/prices/_price.html.erb
+++ b/app/views/prices/_price.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id(price) %>" class="grid grid-cols-12 items-center px-2 border-b border-gray-300 divide-x divide-gray-300 <%= cycle('bg-white', 'bg-gray-50') %>">
+<div id="<%= dom_id(price) %>" class="grid grid-cols-12 items-center px-2 border-b border-gray-300 divide-x divide-gray-300 <%= cycle("bg-white", "bg-gray-50") %>">
   <div class="col-span-3 h-full content-center">
     <p class="py-2 pr-1 sm:pr-2 text-xs sm:text-sm text-gray-700">
       <%= price.city.name %>

--- a/app/views/prices/select_city.html.erb
+++ b/app/views/prices/select_city.html.erb
@@ -1,4 +1,4 @@
 <%= render "shared/modal" do %>
 <!-- app/views/prices/_city_selector.html.erb -->
-<%= render "city_selector", cities: @cities, session_error: @session_error %>
+<%= render "city_selector", cities: @cities %>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,9 +18,13 @@ ja:
   cities:
     index:
       title: 管理者ページ(都市取り込み)
+    links:
+      destroy: 削除
   items:
     index:
       title: 管理者ページ(商品取り込み)
+    links:
+      destroy: 削除
   prices:
     index:
       title: トップページ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   root "prices#index"
 
-  resources :items, only: [ :index ] do
+  resources :items, only: [ :index, :destroy ] do
     collection { post :import }
+    member { get :confirm_destroy }
   end
 
-  resources :cities, only: [ :index ] do
+  resources :cities, only: [ :index, :destroy ] do
     collection { post :import }
   end
 


### PR DESCRIPTION
itemsとcitiesのデータを削除する機能を追加。

その他：
safariで「本当にこのフォームを再送信しますか？」が表示された時に、「OK」を選択すると404エラーページが表示されてしまう問題が依然としてあるため、 status: :found を追加。

itemやcityが削除された場合、関連するpriceのデータも削除されるようにモデルには dependent: :destroy を追加。（テーブルはそのまま）