### PR TITLE
細かな修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   # chromeの検証ツールでデバイスモード使用中に画面遷移をすると406エラーページが表示されるのは以下の"allow_browser versions: :modern"が原因
+  allow_browser versions: :modern
   add_flash_types :success, :danger
   before_action :cleanup_old_interests, if: :should_cleanup?
 

--- a/app/forms/search_prices_form.rb
+++ b/app/forms/search_prices_form.rb
@@ -10,11 +10,8 @@ class SearchPricesForm
   attribute :trend, :string, default: "all"
   attribute :sort_key, :string, default: "newest"
 
-  # 「->」はアロー演算子（lambda）
-  # validates :city_id, presence: true, if: -> { item_name.blank? }
-  # validates :item_name, presence: true, if: -> { city_id.blank? }
-
-  validate :city_or_item_must_be_present
+  # バリデーション設定
+  # validate :city_or_item_must_be_present
   validate :validate_sort_key
 
   def search(page: 1)
@@ -52,11 +49,11 @@ class SearchPricesForm
   private
 
   # カスタムバリデーション
-  def city_or_item_must_be_present
-    if city_id.blank? && item_name.blank?
-      errors.add(:base, :city_or_item_required)
-    end
-  end
+  # def city_or_item_must_be_present
+  #   if city_id.blank? && item_name.blank?
+  #     errors.add(:base, :city_or_item_required)
+  #   end
+  # end
 
   def validate_sort_key
     unless %w[newest price_percentage item_name].include?(sort_key)
@@ -69,11 +66,11 @@ class SearchPricesForm
     scope = scope.joins(:item)
     case sort_key
     when "newest"
-      scope.order(updated_at: :desc, "items.name": :desc)
+      scope.order(updated_at: :desc, "items.name": :asc)
     when "price_percentage"
-      scope.order(price_percentage: :desc, "items.name": :desc)
+      scope.order(price_percentage: :desc, "items.name": :asc)
     when "item_name"
-      scope.order("items.name": :desc)
+      scope.order("items.name": :asc)
     end
   end
 end

--- a/app/views/prices/_consent_form.html.erb
+++ b/app/views/prices/_consent_form.html.erb
@@ -1,31 +1,31 @@
-  <div class="text-center">
-    <p>以下の内容で更新します。</p>
-    <p>よろしいですか？</p>
+<div class="text-center text-xs sm:text-base">
+  <p>以下の内容で更新します。</p>
+  <p>よろしいですか？</p>
+</div>
+<%= form_with url: update_by_city_prices_path, method: :patch, local: true, data: { turbo: false } do |form| %>
+<%= form.hidden_field :city_id, value: @city_id %>
+<div class="my-4">
+  <% @prices.each do |id, attributes| %>
+
+  <div class="flex justify-between px-1 mb-2 text-xs sm:text-base border-b border-gray-300">
+    <p><%= attributes[:name] %></p>
+    <p class="mx-4">価格割合：<%= attributes[:price_percentage] %>%</p>
+    <p>動向：
+      <% if attributes[:trend] == "true" %>
+      <i class="fa-solid fa-arrow-trend-up text-green-500"></i>
+      <% else %>
+      <i class="fa-solid fa-arrow-trend-down text-red-500"></i>
+      <% end %>
+    </p>
+
+    <%= form.hidden_field "prices[#{id}][price_percentage]",  value: attributes[:price_percentage] %>
+    <%= form.hidden_field "prices[#{id}][trend]",  value: attributes[:trend] %>
+
   </div>
-  <%= form_with url: update_by_city_prices_path, method: :patch, local: true, data: { turbo: false } do |form| %>
-  <%= form.hidden_field :city_id, value: @city_id %>
-  <div class="my-4">
-    <% @prices.each do |id, attributes| %>
 
-    <div class="flex mb-2 justify-between border-b border-gray-300">
-      <p><%= attributes[:name] %></p>
-      <p class="mx-4">価格割合：<%= attributes[:price_percentage] %>%</p>
-      <p>動向：
-        <% if attributes[:trend] == "true" %>
-        <i class="fa-solid fa-arrow-trend-up text-green-500"></i>
-        <% else %>
-        <i class="fa-solid fa-arrow-trend-down text-red-500"></i>
-        <% end %>
-      </p>
-
-      <%= form.hidden_field "prices[#{id}][price_percentage]",  value: attributes[:price_percentage] %>
-      <%= form.hidden_field "prices[#{id}][trend]",  value: attributes[:trend] %>
-
-    </div>
-
-    <% end %>
-  </div>
-  <div class="mt-8 text-sm text-white text-center">
-    <%= form.submit t("helpers.submit.confirm"), class: "px-2 py-1 bg-purple-700 rounded cursor-pointer hover:bg-gray-500 transition duration-300" %>
-  </div>
   <% end %>
+</div>
+<div class="mt-8 text-sm text-white text-center">
+  <%= form.submit t("helpers.submit.confirm"), class: "px-2 py-1 text-xs sm:text-base bg-purple-700 rounded cursor-pointer hover:bg-gray-500 transition duration-300" %>
+</div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -6,7 +6,7 @@
     when "danger" then "bg-red-500"
     else "bg-gray-400"
   end %>
-<div class="flex items-center pl-4 py-1 text-sm sm:text-base text-white z-20 animate-flash <%= bg_color %>">
+<div class="flex items-center pl-2 sm:pl-4 py-1 text-sm sm:text-base text-white z-20 animate-flash <%= bg_color %>">
   <%= simple_format(message) %>
 </div>
 <% end %>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -5,5 +5,5 @@ ja:
         search_prices_form:
           attributes:
             base:
-              city_or_item_required: 都市または商品のいずれかを指定してください
+              # city_or_item_required: 都市または商品のいずれかを指定してください
               invalid_sort_key: ソートの指定に問題があるようです

--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,8 @@
 <head>
   <title>404 - ページが見つかりません</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- 5秒後に/(トップページ)へリダイレクト -->
+  <meta http-equiv="refresh" content="5;url=/">
   <style>
   .rails-default-error-page {
     background-color: #EFEFEF;
@@ -57,8 +59,8 @@
 <body class="rails-default-error-page">
   <div class="dialog">
     <div>
-      <h1>お探しのページは存在しません。</h1>
-      <p>アドレスを誤って入力したか、ページが移動した可能性があります。</p>
+      <h1>お探しのページにアクセスできませんでした。</h1>
+      <p>5秒後にトップページへと遷移させます。</p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
細かな修正の内容
・404エラーページが表示された場合、5秒でトップページに遷移するように設定。
・検索時に「都市」または「商品名」の指定を必須とするバリデーションを削除。
（ページネーションがあるので検索結果が多くともあまり問題がないため）
・50音の並び替えをdescからascに修正。
・レスポンシブデザイン関連の修正。